### PR TITLE
Feature to support .html files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # tkhtmlview
+
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fbauripalash%2Ftkhtmlview.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fbauripalash%2Ftkhtmlview?ref=badge_shield)
 
 HTML widgets for tkinter
@@ -6,19 +7,23 @@ HTML widgets for tkinter
 > Fork of [tk_html_widgets](https://github.com/paolo-gurisatti/tk_html_widgets)
 
 ## Overview
+
 This module is a collection of tkinter widgets whose text can be set in HTML format.
 A HTML widget isn't a web browser frame, it's only a simple and lightweight HTML parser that formats the tags used by the tkinter Text base class.
 The widgets behaviour is similar to the PyQt5 text widgets (see the [PyQt5 HTML markup subset](http://doc.qt.io/qt-5/richtext-html-subset.html)).
 
 ## Installation
-``pip install tkhtmlview``
- 
+
+`pip install tkhtmlview`
+
 ## Requirements
- - [Python 3.4 or later](https://www.python.org/downloads/) with tcl/tk support
- - [Pillow 5.3.0](https://github.com/python-pillow/Pillow)
- - requests
+
+- [Python 3.4 or later](https://www.python.org/downloads/) with tcl/tk support
+- [Pillow 5.3.0](https://github.com/python-pillow/Pillow)
+- requests
 
 ## Example
+
 ```python
 import tkinter as tk
 from tkhtmlview import HTMLLabel
@@ -30,60 +35,107 @@ html_label.fit_height()
 root.mainloop()
 ```
 
+You can also save html in a separate .html file and then use `RenderHTML` to render html for widgets.
+
+- _index.html_
+
+    ```html
+    <!DOCTYPE html>
+    <html>
+        <body>
+            <h1>Orange is so Orange</h1>
+            <img
+            src="https://interactive-examples.mdn.mozilla.net/media/cc0-images/grapefruit-slice-332-332.jpg"
+            />
+            <p>
+            The orange is the fruit of various citrus species in the family Rutaceae;
+            it primarily refers to Citrus × sinensis, which is also called sweet
+            orange, to distinguish it from the related Citrus × aurantium, referred to
+            as bitter orange.
+            </p>
+        </body>
+    </html>
+    ```
+
+- _demo.py_
+
+    ```python
+    import tkinter as tk
+    from tkhtmlview import HTMLText, RenderHTML
+
+    root = tk.Tk()
+    html_label = HTMLText(root, html=RenderHTML('index.html'))
+    html_label.pack(fill="both", expand=True)
+    html_label.fit_height()
+    root.mainloop()
+    ```
+
 ## Documentation
 
-### Classes:
+### Classes
+
 All widget classes inherits from the tkinter.Text() base class.
 
 #### class HTMLScrolledText(tkinter.Text)
-> Text-box widget with vertical scrollbar
-#### class HTMLText(tkinter.Text)
-> Text-box widget without vertical scrollbar
-#### class HTMLLabel(tkinter.Text)
-> Text-box widget with label appereance
- 
-### Methods:
-#### def set_html(self, html, strip=True):
-> **Description:** Sets the text in HTML format. <br>
-> **Args:**
->  - *html*: input HTML string
->  - *strip*: if True (default) handles spaces in HTML-like style 
 
-#### def fit_height(self):
+> Text-box widget with vertical scrollbar
+
+#### class HTMLText(tkinter.Text)
+
+> Text-box widget without vertical scrollbar
+
+#### class HTMLLabel(tkinter.Text)
+
+> Text-box widget with label appearance
+
+#### class RenderHTML
+
+> RenderHTML class will render HTML from .html file for the widgets.
+
+### Methods
+
+#### def set_html(self, html, strip=True)
+
+> **Description:** Sets the text in HTML format. <br> > **Args:**
+>
+> - _html_: input HTML string
+> - _strip_: if True (default) handles spaces in HTML-like style
+
+#### def fit_height(self)
+
 > **Description:** Fit widget height in order to display all wrapped lines
 
-### HTML support:
+### HTML support
+
 Only a subset of the whole HTML tags and attributes are supported (see table below).
 Where is possibile, I hope to add more HTML support in the next releases.
 
- **Tags** | **Attributes**  | **Notes** 
---- | --- | ---
-a| style, href | 
-b| style | 
-br|| 
-code | style | 
-div | style | 
-em| style | 
-h1 | style | 
-h2 | style | 
-h3 | style | 
-h4 | style | 
-h5 | style | 
-h6 | style | 
-i| style | 
-img| src, width, height | experimental support for remote images
-li| style | 
-mark| style | 
-ol| style, type | 1, a, A list types only
-p | style | 
-pre | style | 
-span| style | 
-strong| style | 
-u| style | 
-ul| style | bullet glyphs only
-
-
-
+| **Tags** | **Attributes**     | **Notes**                              |
+| -------- | ------------------ | -------------------------------------- |
+| a        | style, href        |
+| b        | style              |
+| br       |                    |
+| code     | style              |
+| div      | style              |
+| em       | style              |
+| h1       | style              |
+| h2       | style              |
+| h3       | style              |
+| h4       | style              |
+| h5       | style              |
+| h6       | style              |
+| i        | style              |
+| img      | src, width, height | experimental support for remote images |
+| li       | style              |
+| mark     | style              |
+| ol       | style, type        | 1, a, A list types only                |
+| p        | style              |
+| pre      | style              |
+| span     | style              |
+| strong   | style              |
+| u        | style              |
+| ul       | style              | bullet glyphs only                     |
 
 ## License
+
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fbauripalash%2Ftkhtmlview.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fbauripalash%2Ftkhtmlview?ref=badge_large)

--- a/tkhtmlview/__init__.py
+++ b/tkhtmlview/__init__.py
@@ -3,14 +3,14 @@ tkinter HTML text widgets
 """
 import sys
 import tkinter as tk
-from tkinter import scrolledtext
-from tkinter import font
 from tkhtmlview import html_parser
+from tkhtmlview.utils import RenderHTML
 
-VERSION = "0.1.0.post1"
+VERSION = "0.1.0.post2"
+
 
 class _ScrolledText(tk.Text):
-    #----------------------------------------------------------------------------------------------
+
     def __init__(self, master=None, **kw):
         self.frame = tk.Frame(master)
 
@@ -21,9 +21,10 @@ class _ScrolledText(tk.Text):
 
         tk.Text.__init__(self, self.frame, **kw)
         self.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        
+
         text_meths = vars(tk.Text).keys()
-        methods = vars(tk.Pack).keys() | vars(tk.Grid).keys() | vars(tk.Place).keys()
+        methods = vars(tk.Pack).keys() | vars(
+            tk.Grid).keys() | vars(tk.Place).keys()
         methods = methods.difference(text_meths)
 
         for m in methods:
@@ -33,22 +34,23 @@ class _ScrolledText(tk.Text):
     def __str__(self):
         return str(self.frame)
 
+
 class HTMLScrolledText(_ScrolledText):
-    #----------------------------------------------------------------------------------------------
+
     """
     HTML scrolled text widget
     """
+
     def __init__(self, *args, html=None, **kwargs):
-        #------------------------------------------------------------------------------------------
         super().__init__(*args, **kwargs)
         self._w_init(kwargs)
         self.html_parser = html_parser.HTMLTextParser()
         if isinstance(html, str):
             self.set_html(html)
-
+        elif isinstance(html, RenderHTML):
+            self.set_html(html.get_html())
 
     def _w_init(self, kwargs):
-        #------------------------------------------------------------------------------------------
         if not 'wrap' in kwargs.keys():
             self.config(wrap='word')
         if not 'background' in kwargs.keys():
@@ -57,9 +59,7 @@ class HTMLScrolledText(_ScrolledText):
             else:
                 self.config(background='white')
 
-
     def fit_height(self):
-        #------------------------------------------------------------------------------------------
         """
         Fit widget height to wrapped lines
         """
@@ -71,9 +71,7 @@ class HTMLScrolledText(_ScrolledText):
         else:
             self.config(height=0.5+3/self.yview()[1])
 
-
     def set_html(self, html, strip=True):
-        #------------------------------------------------------------------------------------------
         """
         Set HTML widget text. If strip is enabled (default) it ignores spaces and new lines.
 
@@ -87,43 +85,41 @@ class HTMLScrolledText(_ScrolledText):
 
 
 class HTMLText(HTMLScrolledText):
-    #----------------------------------------------------------------------------------------------
+
     """
     HTML text widget
     """
+
     def _w_init(self, kwargs):
-        #------------------------------------------------------------------------------------------
         super()._w_init(kwargs)
         self.vbar.pack_forget()
 
     def fit_height(self):
-        #------------------------------------------------------------------------------------------
         super().fit_height()
-        #self.master.update()
+        # self.master.update()
         self.vbar.pack_forget()
 
+
 class HTMLLabel(HTMLText):
-    #----------------------------------------------------------------------------------------------
+
     """
     HTML label widget
     """
+
     def _w_init(self, kwargs):
-        #------------------------------------------------------------------------------------------
         super()._w_init(kwargs)
         if not 'background' in kwargs.keys():
             if sys.platform.startswith('win'):
                 self.config(background='SystemButtonFace')
             else:
                 self.config(background='#d9d9d9')
-                
+
         if not 'borderwidth' in kwargs.keys():
             self.config(borderwidth=0)
 
         if not 'padx' in kwargs.keys():
             self.config(padx=3)
-        
+
     def set_html(self, *args, **kwargs):
-        #------------------------------------------------------------------------------------------
         super().set_html(*args, **kwargs)
         self.config(state=tk.DISABLED)
-

--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -355,9 +355,9 @@ class HTMLTextParser(HTMLParser):
         else:
             self._stack_add(tag, WCfg.FOREGROUND)
 
-        #---------------------------------------------------------------------- [ BACKGROUD_COLOR ]
-        if HTML.Style.BACKGROUD_COLOR in attrs[HTML.Attrs.STYLE].keys():
-            self._stack_add(tag, WCfg.BACKGROUND, attrs[HTML.Attrs.STYLE][HTML.Style.BACKGROUD_COLOR])
+        #---------------------------------------------------------------------- [ BACKGROUND_COLOR ]
+        if HTML.Style.BACKGROUND_COLOR in attrs[HTML.Attrs.STYLE].keys():
+            self._stack_add(tag, WCfg.BACKGROUND, attrs[HTML.Attrs.STYLE][HTML.Style.BACKGROUND_COLOR])
         elif tag == HTML.Tag.MARK:
             self._stack_add(tag, WCfg.BACKGROUND, "yellow")
         else:

--- a/tkhtmlview/utils.py
+++ b/tkhtmlview/utils.py
@@ -1,0 +1,20 @@
+
+import os
+
+
+class RenderHTML:
+    def __init__(self, file):
+        self._file = file
+        if not os.path.exists(self._file):
+            raise FileNotFoundError(f"No such HTML file: {self._file}")
+
+        with open(file, 'r') as f:
+            self._html = f.read()
+    
+    def __repr__(self):
+        return "<%s: %s>" % (self.__class__.__name__, self._file)
+
+    def get_html(self):
+        return str(self._html)
+    __str__ = get_html
+


### PR DESCRIPTION
Rather than typing HTML and python in one single file, I thought separating them will organise and cleans up a lot of code. So I created a **RenderHTML** class that will load the HTML from a separate file and returns an instance that can be passed to `html` _(i.e. `HTMLText(root, html=RenderHTML('index.html'))`)_  parameter of any HTML widgets. 