### PR TITLE
Typo in html parser

### DIFF
--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -355,9 +355,9 @@ class HTMLTextParser(HTMLParser):
         else:
             self._stack_add(tag, WCfg.FOREGROUND)
 
-        #---------------------------------------------------------------------- [ BACKGROUD_COLOR ]
-        if HTML.Style.BACKGROUD_COLOR in attrs[HTML.Attrs.STYLE].keys():
-            self._stack_add(tag, WCfg.BACKGROUND, attrs[HTML.Attrs.STYLE][HTML.Style.BACKGROUD_COLOR])
+        #---------------------------------------------------------------------- [ BACKGROUND_COLOR ]
+        if HTML.Style.BACKGROUND_COLOR in attrs[HTML.Attrs.STYLE].keys():
+            self._stack_add(tag, WCfg.BACKGROUND, attrs[HTML.Attrs.STYLE][HTML.Style.BACKGROUND_COLOR])
         elif tag == HTML.Tag.MARK:
             self._stack_add(tag, WCfg.BACKGROUND, "yellow")
         else:


### PR DESCRIPTION
Creates a problem when running 

```
import tkinter as tk
from tkhtmlview import HTMLLabel

root = tk.Tk()
html_label = HTMLLabel(root, html='<a>Hello</a>')
html_label.pack(fill="both", expand=True)
html_label.fit_height()
root.mainloop()
```
Error: `AttributeError: type object 'Style' has no attribute 'BACKGROUD_COLOR'. Did you mean: 'BACKGROUND_COLOR'?`
Fix: Change BACKGROUD_COLOR to BACKGROUND_COLOR