### PR TITLE
Fixed typo in html_parser.py, line 468

### DIFF
--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -465,7 +465,7 @@ class HTMLTextParser(HTMLParser):
                 self._stack_add(tag, WCfg.TABS, tabs)
 
             elif tag == HTML.Tag.LI:
-                if level := len(self.list_tags):
+                if level != len(self.list_tags):
                     self.list_tags[-1].add()
 
                     if self.strip:


### PR DESCRIPTION
When I imported tkhtmlview and tried to use it, I got the following error message:
`File "/Users/jp/Desktop/AAAAAA_Regorg/projects/Dice_Roller/env/lib/python3.7/site-packages/tkhtmlview/html_parser.py", line 468
    if level := len(self.list_tags):`

After changing the  colon to an explanation point, its running smoothly.
