### PR TITLE
Python 3.7 compatibility

### DIFF
--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -494,7 +494,8 @@ class HTMLTextParser(HTMLParser):
                 self._stack_add(tag, WCfg.TABS, tabs)
 
             elif tag == HTML.Tag.LI:
-                if level := len(self.list_tags):
+                level = len(self.list_tags)
+                if level:
                     self.list_tags[-1].add()
 
                     if self.strip:


### PR DESCRIPTION
Hi,

I'm trying to use this from a project that support Python >= 3.7, but currently our tests are failing on 3.7 because of this usage of the walrus operator which was introduced in Python 3.8. The Poetry config suggests that this project works on 3.7, so I'm hoping this will be accepted and released.

Thank you!