### PR TITLE
Update html_parser.py

### DIFF
--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -696,6 +696,9 @@ class HTMLTextParser(HTMLParser):
         # add tags
         self.hlink_slots = []
         for key, tag in self._w_tags.items():
+            if "config" in tag: # HF change justify to left for tkinter (only supports left, right, center)
+                if tag["config"].get("justify") == "justify":
+                    tag["config"]["justify"] = "left"
             self._w.tag_add(key, tag[WTag.START_INDEX], tag[WTag.END_INDEX])
             self._w.tag_config(key, font=font.Font(**tag[Fnt.KEY]), **tag[WCfg.KEY])
             if tag[Bind.KEY][Bind.LINK]:

--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -12,77 +12,79 @@ from collections import OrderedDict
 import requests
 from io import BytesIO
 
-
-# __________________________________________________________________________________________________
-class Defs:
+#__________________________________________________________________________________________________
+class Defs():
     DEFAULT_TEXT_FONT_FAMILY = ("Segoe ui", "Calibri", "Helvetica", "TkTextFont")
     FONT_SIZE = 14
     PREFORMATTED_FONT_FAMILY = ("Courier", "DejaVu Sans Mono", "TkFixedFont")
     HEADINGS_FONT_SIZE = {
-        "h1": 32,
-        "h2": 24,
-        "h3": 18,
-        "h4": 16,
-        "h5": 13,
-        "h6": 10,
+        'h1':32,
+        'h2':24,
+        'h3':18,
+        'h4':16,
+        'h5':13,
+        'h6':10,
     }
 
 
 class HTML:
-    # ----------------------------------------------------------------------------------------------
+    #----------------------------------------------------------------------------------------------
     """
-    List of supported HTML tags and attrs
+    List of supported HTML tags and attrs 
     """
+    class Tag():
+        BR = 'br'
+        UL = 'ul'
+        OL = 'ol'
+        LI = 'li'
+        IMG = 'img'
+        A = 'a'
+        B = 'b'
+        STRONG = 'strong'
+        I = 'i'
+        EM = 'em'
+        U = 'u'
+        MARK = 'mark'
+        SPAN = 'span'
+        DIV = 'div'
+        P = 'p'
+        PRE = 'pre'
+        CODE = 'code'
+        H1 = 'h1'
+        H2 = 'h2'
+        H3 = 'h3'
+        H4 = 'h4'
+        H5 = 'h5'
+        H6 = 'h6'
+        TABLE = "table"
+        TR = "tr"
+        TH = "th"
+        TD = "td"
 
-    class Tag:
-        BR = "br"
-        UL = "ul"
-        OL = "ol"
-        LI = "li"
-        IMG = "img"
-        A = "a"
-        B = "b"
-        STRONG = "strong"
-        I = "i"
-        EM = "em"
-        U = "u"
-        MARK = "mark"
-        SPAN = "span"
-        DIV = "div"
-        P = "p"
-        PRE = "pre"
-        CODE = "code"
-        H1 = "h1"
-        H2 = "h2"
-        H3 = "h3"
-        H4 = "h4"
-        H5 = "h5"
-        H6 = "h6"
+    class Attrs():
+        STYLE = 'style'
+        HREF ='href'
+        SRC = 'src'
+        WIDTH = 'width'
+        HEIGHT = 'height'
+        TYPE = 'type'
 
-    class Attrs:
-        STYLE = "style"
-        HREF = "href"
-        SRC = "src"
-        WIDTH = "width"
-        HEIGHT = "height"
-        TYPE = "type"
+    class TypeOrderedList():
+        _1 = '1'
+        a = 'a'
+        A = 'A'
 
-    class TypeOrderedList:
-        _1 = "1"
-        a = "a"
-        A = "A"
+    class Style():
+        COLOR = 'color'
+        BACKGROUD_COLOR = 'background-color'
+        FONT_FAMILY = 'font-family'
+        FONT_SIZE = 'font-size'
+        TEXT_ALIGN = 'text-align'
+        TEXT_DECORATION = 'text-decoration'
 
-    class Style:
-        COLOR = "color"
-        BACKGROUND_COLOR = "background-color"
-        FONT_FAMILY = "font-family"
-        FONT_SIZE = "font-size"
-        TEXT_ALIGN = "text-align"
-        TEXT_DECORATION = "text-decoration"
-
-    class StyleTextDecoration:
-        UNDERLINE = "underline"
-        LINE_THROUGH = "line-through"
+    class StyleTextDecoration():
+        UNDERLINE = 'underline'
+        LINE_THROUGH = 'line-through'
 
     HEADING_TAGS = (
         Tag.H1,
@@ -101,7 +103,7 @@ class HTML:
         Tag.P,
         Tag.PRE,
         Tag.CODE,
-    )
+    ) 
 
     NEW_LINE_TAGS = HEADING_TAGS + (
         Tag.UL,
@@ -110,7 +112,9 @@ class HTML:
         Tag.P,
         Tag.PRE,
         Tag.CODE,
-    )
+        Tag.TABLE,
+        Tag.TR,
+    )  
 
     STYLE_TAGS = TEXT_ALIGN_TAGS + (
         Tag.A,
@@ -121,22 +125,23 @@ class HTML:
         Tag.U,
         Tag.MARK,
         Tag.SPAN,
+        Tag.TD,
+        Tag.TH,
     )
 
 
-# --------------------------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------------------------
 # Text widget defs
 
-
-class WCfg:
+class WCfg():
     KEY = "config"
     BACKGROUND = "background"
     FOREGROUND = "foreground"
     JUSTIFY = "justify"
     TABS = "tabs"
 
-
-class Fnt:
+class Fnt():
     KEY = "font"
     FAMILY = "family"
     SIZE = "size"
@@ -145,104 +150,99 @@ class Fnt:
     UNDERLINE = "underline"
     OVERSTRIKE = "overstrike"
 
-
-class Bind:
+class Bind():
     KEY = "bind"
     LINK = "link"
     IMAGE = "image"
 
-
-class WTag:
+class WTag():
     START_INDEX = "start_index"
     END_INDEX = "end_index"
 
-
 DEFAULT_STACK = {
-    WCfg.KEY: {
-        WCfg.BACKGROUND: [],
-        WCfg.FOREGROUND: [("__DEFAULT__", "black")],
-        WCfg.JUSTIFY: [("__DEFAULT__", "left")],
-        WCfg.TABS: [("__DEFAULT__", ())],
+    WCfg.KEY:{
+        WCfg.BACKGROUND:[],
+        WCfg.FOREGROUND:[("__DEFAULT__", "black")],
+        WCfg.JUSTIFY:[("__DEFAULT__", 'left')],
+        WCfg.TABS:[("__DEFAULT__", ())],
     },
-    Fnt.KEY: {
-        Fnt.FAMILY: [],
-        Fnt.SIZE: [("__DEFAULT__", Defs.FONT_SIZE)],
-        Fnt.WEIGHT: [("__DEFAULT__", "normal")],
-        Fnt.SLANT: [("__DEFAULT__", "roman")],
-        Fnt.UNDERLINE: [("__DEFAULT__", False)],
-        Fnt.OVERSTRIKE: [("__DEFAULT__", False)],
+    Fnt.KEY:{
+        Fnt.FAMILY:[],
+        Fnt.SIZE:[("__DEFAULT__", Defs.FONT_SIZE)],
+        Fnt.WEIGHT:[("__DEFAULT__", 'normal')],
+        Fnt.SLANT:[("__DEFAULT__", 'roman')],
+        Fnt.UNDERLINE:[("__DEFAULT__", False)],
+        Fnt.OVERSTRIKE:[("__DEFAULT__", False)],
     },
-    Bind.KEY: {
-        Bind.LINK: [("__DEFAULT__", None)],
+    Bind.KEY:{
+        Bind.LINK:[("__DEFAULT__", None)],
     },
 }
 
-
-# __________________________________________________________________________________________________
+#__________________________________________________________________________________________________
 # functions
 def get_existing_font(font_families):
-    # ------------------------------------------------------------------------------------------
+    #------------------------------------------------------------------------------------------
     try:
-        return next(
-            filter(
-                lambda f: f.lower() in (f.lower() for f in font.families()),
-                font_families,
-            )
-        )
+        return next(filter(lambda f: f.lower() in (f.lower() for f in font.families()), font_families))
     except:
         return "TkTextFont"
 
 
-# __________________________________________________________________________________________________
+#__________________________________________________________________________________________________
 # classes
-class HLinkSlot:
-    # ----------------------------------------------------------------------------------------------
+class HLinkSlot():
+    #----------------------------------------------------------------------------------------------
 
     def __init__(self, w, tag_name, url):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         self._w = w
         self.tag_name = tag_name
         self.URL = url
 
     def call(self, event):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         webbrowser.open(self.URL)
         self._w.tag_config(self.tag_name, foreground="purple")
 
     def enter(self, event):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         self._w.config(cursor="hand2")
 
     def leave(self, event):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         self._w.config(cursor="")
 
 
-class ListTag:
-    # ----------------------------------------------------------------------------------------------
-    def __init__(self, ordered: bool, list_type=None):
-        # ------------------------------------------------------------------------------------------
+
+
+class ListTag():
+    #----------------------------------------------------------------------------------------------
+    def __init__(self, ordered:bool, list_type=None):
+        #------------------------------------------------------------------------------------------
         self.ordered = ordered
         self.type = list_type
         self.index = 0
 
     def add(self):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         if self.ordered:
             self.index += 1
 
     def line_index(self):
-        if not self.ordered:
+        #------------------------------------------------------------------------------------------
+        if self.ordered:
+            if self.type == HTML.TypeOrderedList._1:
+                return str(self.index)
+            elif self.type == HTML.TypeOrderedList.a:
+                return self._index_to_str(self.index).lower()
+            elif self.type == HTML.TypeOrderedList.A:
+                return self._index_to_str(self.index).upper()
+        else:
             return chr(8226)
-        if self.type == HTML.TypeOrderedList._1:
-            return str(self.index)
-        elif self.type == HTML.TypeOrderedList.a:
-            return self._index_to_str(self.index).lower()
-        elif self.type == HTML.TypeOrderedList.A:
-            return self._index_to_str(self.index).upper()
-
+    
     def _index_to_str(self, index):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         prefix = ""
         if index > 26:
             prefix = self._index_to_str(index // 26)
@@ -251,11 +251,12 @@ class ListTag:
         return prefix + chr(0x60 + index)
 
 
+
 class HTMLTextParser(HTMLParser):
-    # ----------------------------------------------------------------------------------------------
+    #----------------------------------------------------------------------------------------------
 
     def __init__(self):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         super().__init__()
         # set list tabs
         self.cached_images = {}
@@ -263,15 +264,16 @@ class HTMLTextParser(HTMLParser):
         self.DEFAULT_TEXT_FONT_FAMILY = get_existing_font(Defs.DEFAULT_TEXT_FONT_FAMILY)
         self.PREFORMATTED_FONT_FAMILY = get_existing_font(Defs.PREFORMATTED_FONT_FAMILY)
 
+
     def _parse_attrs(self, attrs):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         attrs_dict = {
-            HTML.Attrs.STYLE: {},
-            HTML.Attrs.HREF: None,
-            HTML.Attrs.SRC: None,
-            HTML.Attrs.WIDTH: None,
-            HTML.Attrs.HEIGHT: None,
-            HTML.Attrs.TYPE: None,
+            HTML.Attrs.STYLE:{},
+            HTML.Attrs.HREF:None,
+            HTML.Attrs.SRC:None,
+            HTML.Attrs.WIDTH:None,
+            HTML.Attrs.HEIGHT:None,
+            HTML.Attrs.TYPE:None,
         }
         for k, v in attrs:
             k = k.lower()
@@ -283,19 +285,18 @@ class HTMLTextParser(HTMLParser):
                         attrs_dict[HTML.Attrs.STYLE][p_key] = p_value
                     except:
                         pass
-            elif k in (
-                HTML.Attrs.HREF,
-                HTML.Attrs.SRC,
-                HTML.Attrs.WIDTH,
-                HTML.Attrs.HEIGHT,
-                HTML.Attrs.TYPE,
-            ):
+            elif k in (HTML.Attrs.HREF, HTML.Attrs.SRC, HTML.Attrs.WIDTH, HTML.Attrs.HEIGHT, HTML.Attrs.TYPE):
                 attrs_dict[k] = v
         return attrs_dict
 
+
     def _w_tags_add(self):
-        # ------------------------------------------------------------------------------------------
-        tag = {WCfg.KEY: {}, Fnt.KEY: {}, Bind.KEY: {}}
+        #------------------------------------------------------------------------------------------
+        tag = {
+            WCfg.KEY:{},
+            Fnt.KEY:{},
+            Bind.KEY:{}
+        }
 
         for k1 in (WCfg.KEY, Fnt.KEY, Bind.KEY):
             for k2 in DEFAULT_STACK[k1]:
@@ -303,8 +304,9 @@ class HTMLTextParser(HTMLParser):
 
         self._w_tags[self._w.index("end-1c")] = tag
 
+
     def _stack_get_main_key(self, key):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         if key in WCfg.__dict__.values():
             main_key = WCfg.KEY
         elif key in Fnt.__dict__.values():
@@ -313,21 +315,23 @@ class HTMLTextParser(HTMLParser):
             main_key = Bind.KEY
         else:
             raise ValueError("key %s doesn't exists" % key)
-
+        
         return main_key
 
-    def _stack_add(self, tag, key, value=None):
-        # ------------------------------------------------------------------------------------------
-        main_key = self._stack_get_main_key(key)
 
+    def _stack_add(self, tag, key, value=None):
+        #------------------------------------------------------------------------------------------
+        main_key = self._stack_get_main_key(key)
+        
         if value is None:
             # if value is none, add the previous value
-            value = self.stack[main_key][key][-1][1]
-
+            value =  self.stack[main_key][key][-1][1]
+        
         self.stack[main_key][key].append((tag, value))
 
+
     def _stack_index(self, tag, key):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         main_key = self._stack_get_main_key(key)
         index = None
         for i, v in enumerate(self.stack[main_key][key]):
@@ -336,42 +340,38 @@ class HTMLTextParser(HTMLParser):
 
         return index
 
+
     def _stack_pop(self, tag, key):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         main_key = self._stack_get_main_key(key)
 
         index = None
         if len(self.stack[main_key][key]) > 1:
             index = self._stack_index(tag, key)
-
+        
         if index is not None:
             return self.stack[main_key][key].pop(index)[1]
 
+
     def _parse_styles(self, tag, attrs):
-        # ------------------------------------------------------------------------------------------
-        # -------------------------------------------------------------------------------- [ COLOR ]
+        #------------------------------------------------------------------------------------------
+        #-------------------------------------------------------------------------------- [ COLOR ]
         if HTML.Style.COLOR in attrs[HTML.Attrs.STYLE].keys():
-            self._stack_add(
-                tag, WCfg.FOREGROUND, attrs[HTML.Attrs.STYLE][HTML.Style.COLOR]
-            )
+            self._stack_add(tag, WCfg.FOREGROUND, attrs[HTML.Attrs.STYLE][HTML.Style.COLOR])
         elif tag == HTML.Tag.A and attrs[HTML.Attrs.HREF]:
             self._stack_add(tag, WCfg.FOREGROUND, "blue")
         else:
             self._stack_add(tag, WCfg.FOREGROUND)
 
-        # ---------------------------------------------------------------------- [ BACKGROUND_COLOR ]
-        if HTML.Style.BACKGROUND_COLOR in attrs[HTML.Attrs.STYLE].keys():
-            self._stack_add(
-                tag,
-                WCfg.BACKGROUND,
-                attrs[HTML.Attrs.STYLE][HTML.Style.BACKGROUND_COLOR],
-            )
+        #---------------------------------------------------------------------- [ BACKGROUD_COLOR ]
+        if HTML.Style.BACKGROUD_COLOR in attrs[HTML.Attrs.STYLE].keys():
+            self._stack_add(tag, WCfg.BACKGROUND, attrs[HTML.Attrs.STYLE][HTML.Style.BACKGROUD_COLOR])
         elif tag == HTML.Tag.MARK:
             self._stack_add(tag, WCfg.BACKGROUND, "yellow")
         else:
             self._stack_add(tag, WCfg.BACKGROUND)
 
-        # -------------------------------------------------------------------------- [ FONT_FAMILY ]
+        #-------------------------------------------------------------------------- [ FONT_FAMILY ]
         # font family
         if HTML.Style.FONT_FAMILY in attrs[HTML.Attrs.STYLE].keys():
             font_family = Defs.DEFAULT_TEXT_FONT_FAMILY
@@ -386,7 +386,7 @@ class HTMLTextParser(HTMLParser):
         else:
             self._stack_add(tag, Fnt.FAMILY)
 
-        # ---------------------------------------------------------------------------- [ FONT_SIZE ]
+        #---------------------------------------------------------------------------- [ FONT_SIZE ]
         if HTML.Style.FONT_SIZE in attrs[HTML.Attrs.STYLE].keys():
             size = Defs.FONT_SIZE
             if attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE].endswith("px"):
@@ -394,106 +394,89 @@ class HTMLTextParser(HTMLParser):
                     size = int(attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE][:-2])
             elif attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE].endswith(r"%"):
                 if attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE][:-1].isdigit():
-                    size = int(
-                        (
-                            int(attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE][:-1])
-                            * Defs.FONT_SIZE
-                        )
-                        / 100
-                    )
+                    size = int((int(attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE][:-1]) * Defs.FONT_SIZE)/100)
             self._stack_add(tag, Fnt.SIZE, size)
-        elif tag.startswith("h") and len(tag) == 2:
+        elif tag.startswith('h') and len(tag) == 2:
             self._stack_add(tag, Fnt.SIZE, Defs.HEADINGS_FONT_SIZE[tag])
         else:
             self._stack_add(tag, Fnt.SIZE)
 
-        # --------------------------------------------------------------------------- [ TEXT_ALIGN ]
-        if (
-            HTML.Style.TEXT_ALIGN in attrs[HTML.Attrs.STYLE].keys()
-            and tag in HTML.TEXT_ALIGN_TAGS
-        ):
-            self._stack_add(
-                tag, WCfg.JUSTIFY, attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_ALIGN]
-            )
+        #--------------------------------------------------------------------------- [ TEXT_ALIGN ]
+        if HTML.Style.TEXT_ALIGN in attrs[HTML.Attrs.STYLE].keys() and tag in HTML.TEXT_ALIGN_TAGS:
+            self._stack_add(tag, WCfg.JUSTIFY, attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_ALIGN])
         else:
             self._stack_add(tag, WCfg.JUSTIFY)
 
-        # ---------------------------------------------------------------------- [ TEXT_DECORATION ]
+        #---------------------------------------------------------------------- [ TEXT_DECORATION ]
         if HTML.Style.TEXT_DECORATION in attrs[HTML.Attrs.STYLE].keys():
             if tag == HTML.Tag.STRONG:
                 self._stack_add(tag, Fnt.UNDERLINE, False)
                 self._stack_add(tag, Fnt.OVERSTRIKE, False)
-            elif (
-                HTML.StyleTextDecoration.UNDERLINE
-                in attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_DECORATION]
-            ):
+            elif HTML.StyleTextDecoration.UNDERLINE in attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_DECORATION]:
                 self._stack_add(tag, Fnt.UNDERLINE, True)
                 self._stack_add(tag, Fnt.OVERSTRIKE, False)
-            elif (
-                HTML.StyleTextDecoration.LINE_THROUGH
-                in attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_DECORATION]
-            ):
+            elif HTML.StyleTextDecoration.LINE_THROUGH in attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_DECORATION]:
                 self._stack_add(tag, Fnt.UNDERLINE, False)
                 self._stack_add(tag, Fnt.OVERSTRIKE, True)
             else:
                 self._stack_add(tag, Fnt.UNDERLINE)
                 self._stack_add(tag, Fnt.OVERSTRIKE)
-        elif tag == HTML.Tag.A and attrs[HTML.Attrs.HREF]:
-            self._stack_add(tag, Fnt.UNDERLINE, True)
-            self._stack_add(tag, Fnt.OVERSTRIKE, False)
-        elif tag == HTML.Tag.U:
-            self._stack_add(tag, Fnt.UNDERLINE, True)
-            self._stack_add(tag, Fnt.OVERSTRIKE, False)
         else:
-            self._stack_add(tag, Fnt.UNDERLINE)
-            self._stack_add(tag, Fnt.OVERSTRIKE)
+            if tag == HTML.Tag.A and attrs[HTML.Attrs.HREF]:
+                self._stack_add(tag, Fnt.UNDERLINE, True)
+                self._stack_add(tag, Fnt.OVERSTRIKE, False)
+            elif tag == HTML.Tag.U:
+                self._stack_add(tag, Fnt.UNDERLINE, True)
+                self._stack_add(tag, Fnt.OVERSTRIKE, False)
+            else:
+                self._stack_add(tag, Fnt.UNDERLINE)
+                self._stack_add(tag, Fnt.OVERSTRIKE)
+
 
     def handle_starttag(self, tag, attrs):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         tag = tag.lower()
         attrs = self._parse_attrs(attrs)
 
         if tag in HTML.STYLE_TAGS:
-            # ---------------------------------------------------------------------- [ STYLED_TAGS ]
+            #---------------------------------------------------------------------- [ STYLED_TAGS ]
             self._parse_styles(tag, attrs)
 
             if tag == HTML.Tag.B or tag == HTML.Tag.STRONG or tag in HTML.HEADING_TAGS:
                 self._stack_add(tag, Fnt.WEIGHT, "bold")
 
-            elif tag in [HTML.Tag.I, HTML.Tag.EM]:
+            elif tag == HTML.Tag.I or tag == HTML.Tag.EM:
                 self._stack_add(tag, Fnt.SLANT, "italic")
 
             elif tag == HTML.Tag.A:
                 self._stack_add(tag, Bind.LINK, attrs[HTML.Attrs.HREF])
 
             elif tag == HTML.Tag.OL:
-                # ---------------------------------------------------------------- [ ORDERED_LISTS ]
-                if (
-                    attrs[HTML.Attrs.TYPE]
-                    and attrs[HTML.Attrs.TYPE] in HTML.TypeOrderedList.__dict__.values()
-                ):
+                #---------------------------------------------------------------- [ ORDERED_LISTS ]
+                if attrs[HTML.Attrs.TYPE] and attrs[HTML.Attrs.TYPE] in HTML.TypeOrderedList.__dict__.values():
                     list_type = attrs[HTML.Attrs.TYPE]
                 else:
                     list_type = HTML.TypeOrderedList._1
                 self.list_tags.append(ListTag(ordered=True, list_type=list_type))
-
+                
                 tabs = []
                 for i in range(len(self.list_tags)):
                     offset = 30 * (i + 1)
-                    tabs += [offset, tk.RIGHT, offset + 5, tk.LEFT]
+                    tabs += [offset, tk.RIGHT, offset+5, tk.LEFT ]
                 self._stack_add(tag, WCfg.TABS, tabs)
 
             elif tag == HTML.Tag.UL:
-                # -------------------------------------------------------------- [ UNORDERED_LISTS ]
+                #-------------------------------------------------------------- [ UNORDERED_LISTS ]
                 self.list_tags.append(ListTag(ordered=False))
 
                 tabs = []
                 for i in range(len(self.list_tags)):
                     offset = 30 * (i + 1)
-                    tabs += [offset, tk.RIGHT, offset + 5, tk.LEFT]
+                    tabs += [offset, tk.RIGHT, offset+5, tk.LEFT ]
                 self._stack_add(tag, WCfg.TABS, tabs)
 
             elif tag == HTML.Tag.LI:
+                #------------------------------------------------------------------ [ LISTS_LINES ]
                 level = len(self.list_tags)
                 if level:
                     self.list_tags[-1].add()
@@ -503,31 +486,32 @@ class HTMLTextParser(HTMLParser):
 
                     line_index = self.list_tags[-1].line_index()
                     if self.list_tags[-1].ordered:
-                        line_index = "\t" + "\t\t" * (level - 1) + line_index + ".\t"
+                        line_index = "\t" + "\t\t" * (level-1) + line_index + ".\t"
                     else:
-                        line_index = "\t" + "\t\t" * (level - 1) + line_index + "\t"
-
+                        line_index = "\t" + "\t\t" * (level-1) + line_index + "\t"
+                    
                     self._stack_add(tag, Fnt.UNDERLINE, False)
                     self._stack_add(tag, Fnt.OVERSTRIKE, False)
                     self._w_tags_add()
                     self._w.insert(tk.INSERT, line_index)
                     self._stack_pop(tag, Fnt.UNDERLINE)
                     self._stack_pop(tag, Fnt.OVERSTRIKE)
+                    
+            elif tag == HTML.Tag.TD or tag == HTML.Tag.TD:
+                    self._w.insert(tk.INSERT, "\t")
 
         elif tag == HTML.Tag.IMG and attrs[HTML.Attrs.SRC]:
-            # -------------------------------------------------------------------- [ UNSTYLED_TAGS ]
+            #-------------------------------------------------------------------- [ UNSTYLED_TAGS ]
             image = None
-            # print(attrs[HTML.Attrs.SRC] , self.cached_images)
-            if attrs[HTML.Attrs.SRC].startswith(("https://", "ftp://", "http://")):
+            print(attrs[HTML.Attrs.SRC] , self.cached_images)
+            if attrs[HTML.Attrs.SRC].startswith(("https://" , "ftp://" , "http://")):
                 if attrs[HTML.Attrs.SRC] in self.cached_images.keys():
                     image = deepcopy(self.cached_images[attrs[HTML.Attrs.SRC]])
                 else:
                     try:
-                        image = Image.open(
-                            BytesIO(requests.get(attrs[HTML.Attrs.SRC]).content)
-                        )
+                        image = Image.open(BytesIO(requests.get(attrs[HTML.Attrs.SRC]).content))
                         self.cached_images[attrs[HTML.Attrs.SRC]] = deepcopy(image)
-                    except:
+                    except :
                         pass
 
             if attrs[HTML.Attrs.SRC] in self.cached_images.keys():
@@ -548,96 +532,109 @@ class HTMLTextParser(HTMLParser):
                 if resize:
                     image = image.resize((width, height), Image.ANTIALIAS)
                 self.images.append(ImageTk.PhotoImage(image))
-                self._w.image_create(tk.INSERT, image=self.images[-1])
+                self._w.image_create(tk.INSERT, image=self.images[-1]) 
+                
+        elif tag == HTML.Tag.TABLE:
+                tabs = []
+                for i in range(30): # HF waslen(self.list_tags)):
+                    offset = 40 * (i + 1)
+                    tabs += [offset, tk.LEFT ]
+                self._stack_add(tag, WCfg.TABS, tabs)
+            
 
         if self.strip:
+            #------------------------------------------------------------------------ [ NEW_LINES ]
             if tag == HTML.Tag.BR:
                 self._insert_new_line()
             else:
                 self.html_tags.append(tag)
 
-        if (
-            tag in HTML.NEW_LINE_TAGS
-            and self.strip
-            and self._w.index("end-1c") != "1.0"
-        ):
-            if tag in (HTML.Tag.DIV,):
-                self._insert_new_line()
-            elif tag in (HTML.Tag.UL, HTML.Tag.OL):
-                if len(self.list_tags) == 1:
+            if tag in HTML.NEW_LINE_TAGS and self.strip and self._w.index("end-1c") != "1.0":
+                if tag in (HTML.Tag.DIV,):
+                    self._insert_new_line()
+                elif tag in (HTML.Tag.UL, HTML.Tag.OL):
+                    if len(self.list_tags) == 1:
+                        self._insert_new_line(double=True)
+                    else:
+                        self._insert_new_line(double=False)
+                else:       
                     self._insert_new_line(double=True)
-                else:
-                    self._insert_new_line(double=False)
-            else:
-                self._insert_new_line(double=True)
 
         self._w_tags_add()
 
+
     def handle_charref(self, data):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         try:
             char = chr(int(data))
             self._w.insert(tk.INSERT, char)
         except:
             pass
 
+
     def _insert_new_line(self, double=False):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         self._remove_last_space()
         if self._w.get("end-3c", "end-1c") == "\n\n":
             pass
         elif self._w.get("end-2c", "end-1c") == "\n":
             if double:
                 self._w.insert(tk.INSERT, "\n")
-        elif double:
-            self._w.insert(tk.INSERT, "\n\n")
         else:
-            self._w.insert(tk.INSERT, "\n")
+            if double:
+                self._w.insert(tk.INSERT, "\n\n")
+            else:
+                self._w.insert(tk.INSERT, "\n")
+
 
     def _text_rstrip(self):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         for _ in range(3):
             if self._w.get("end-2c", "end-1c") in (" ", "\n"):
                 self._w.delete("end-2c", "end-1c")
 
+
     def _remove_last_space(self):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         if self._w.get("end-2c", "end-1c") == " ":
             self._w.delete("end-2c", "end-1c")
 
+
     def _remove_multi_spaces(self, data):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         data = data.replace("  ", " ")
         if "  " in data:
             data = self._remove_multi_spaces(data)
         return data
 
-    def handle_data(self, data):
-        if len(self.html_tags) and self.html_tags[-1] in (HTML.Tag.PRE, HTML.Tag.CODE):
-            pass
-        elif not data.strip():
-            if self.strip:
-                data = ""
-        elif self.strip:
-            # left strip
-            if self._w.index("end-1c").endswith(".0"):
-                data = data.lstrip()
-            elif self._w.get("end-2c", "end-1c") == " ":
-                data = data.lstrip()
 
-            data = data.replace("\n", " ").replace("\t", " ")
-            data = f"{data} "
-            data = self._remove_multi_spaces(data)
-            if len(self.html_tags) and self.html_tags[-1] in (
-                HTML.Tag.UL,
-                HTML.Tag.OL,
-            ):
-                self._w.insert(tk.INSERT, "\t" * 2 * len(self.list_tags))
+    def handle_data(self, data):
+        #------------------------------------------------------------------------------------------
+        if self.strip:
+            if len(self.html_tags) and self.html_tags[-1] in (HTML.Tag.PRE, HTML.Tag.CODE):
+                pass
+            elif not data.strip():
+                data = ""
+            else:
+                # left strip
+                if self._w.index("end-1c").endswith(".0"):
+                    data = data.lstrip()
+                elif self._w.get("end-2c", "end-1c") == " ":
+                    data = data.lstrip()
+
+                data = data.replace("\n", " ").replace("\t", " ")
+                data = data + " "
+                data = self._remove_multi_spaces(data)
+                if len(self.html_tags):
+                    level = len(self.list_tags)
+                    if self.html_tags[-1] in (HTML.Tag.UL, HTML.Tag.OL):
+                        self._w.insert(tk.INSERT, "\t" * 2 * level)
 
         self._w.insert(tk.INSERT, data)
 
+
     def handle_endtag(self, tag):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         tag = tag.lower()
 
         try:
@@ -647,6 +644,7 @@ class HTMLTextParser(HTMLParser):
             pass
 
         if tag in HTML.STYLE_TAGS:
+
             self._stack_pop(tag, WCfg.FOREGROUND)
             self._stack_pop(tag, WCfg.BACKGROUND)
             self._stack_pop(tag, WCfg.JUSTIFY)
@@ -658,13 +656,13 @@ class HTMLTextParser(HTMLParser):
             if tag == HTML.Tag.B or tag == HTML.Tag.STRONG or tag in HTML.HEADING_TAGS:
                 self._stack_pop(tag, Fnt.WEIGHT)
 
-            elif tag in [HTML.Tag.I, HTML.Tag.EM]:
+            elif tag == HTML.Tag.I or tag == HTML.Tag.EM:
                 self._stack_pop(tag, Fnt.SLANT)
 
             elif tag == HTML.Tag.A:
                 self._stack_pop(tag, Bind.LINK)
 
-            elif tag in [HTML.Tag.OL, HTML.Tag.UL]:
+            elif tag == HTML.Tag.OL or tag == HTML.Tag.UL:
                 if len(self.list_tags):
                     self.list_tags = self.list_tags[:-1]
 
@@ -682,8 +680,9 @@ class HTMLTextParser(HTMLParser):
             else:
                 self._insert_new_line(double=True)
 
+
     def _w_tags_apply_all(self):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         # update indexes
         if self.strip:
             self._text_rstrip()
@@ -696,29 +695,24 @@ class HTMLTextParser(HTMLParser):
         # add tags
         self.hlink_slots = []
         for key, tag in self._w_tags.items():
-            if "config" in tag: # HF change justify to left for tkinter (only supports left, right, center)
+            if "config" in tag: # HF change to change justify to fill for tkinter
                 if tag["config"].get("justify") == "justify":
                     tag["config"]["justify"] = "left"
             self._w.tag_add(key, tag[WTag.START_INDEX], tag[WTag.END_INDEX])
             self._w.tag_config(key, font=font.Font(**tag[Fnt.KEY]), **tag[WCfg.KEY])
             if tag[Bind.KEY][Bind.LINK]:
-                self.hlink_slots.append(
-                    HLinkSlot(self._w, key, tag[Bind.KEY][Bind.LINK])
-                )
+                self.hlink_slots.append(HLinkSlot(self._w, key, tag[Bind.KEY][Bind.LINK]))
                 self._w.tag_bind(key, "<Button-1>", self.hlink_slots[-1].call)
                 self._w.tag_bind(key, "<Leave>", self.hlink_slots[-1].leave)
                 self._w.tag_bind(key, "<Enter>", self.hlink_slots[-1].enter)
+        
 
     def w_set_html(self, w, html, strip):
-        # ------------------------------------------------------------------------------------------
+        #------------------------------------------------------------------------------------------
         self._w = w
         self.stack = deepcopy(DEFAULT_STACK)
-        self.stack[WCfg.KEY][WCfg.BACKGROUND].append(
-            ("__DEFAULT__", self._w.cget("background"))
-        )
-        self.stack[Fnt.KEY][Fnt.FAMILY].append(
-            ("__DEFAULT__", self.DEFAULT_TEXT_FONT_FAMILY)
-        )
+        self.stack[WCfg.KEY][WCfg.BACKGROUND].append(("__DEFAULT__", self._w.cget("background")))
+        self.stack[Fnt.KEY][Fnt.FAMILY].append(("__DEFAULT__", self.DEFAULT_TEXT_FONT_FAMILY))
         self._w_tags = OrderedDict()
         self.html_tags = []
         self.images = []

--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -12,79 +12,77 @@ from collections import OrderedDict
 import requests
 from io import BytesIO
 
-#__________________________________________________________________________________________________
-class Defs():
+
+# __________________________________________________________________________________________________
+class Defs:
     DEFAULT_TEXT_FONT_FAMILY = ("Segoe ui", "Calibri", "Helvetica", "TkTextFont")
     FONT_SIZE = 14
     PREFORMATTED_FONT_FAMILY = ("Courier", "DejaVu Sans Mono", "TkFixedFont")
     HEADINGS_FONT_SIZE = {
-        'h1':32,
-        'h2':24,
-        'h3':18,
-        'h4':16,
-        'h5':13,
-        'h6':10,
+        "h1": 32,
+        "h2": 24,
+        "h3": 18,
+        "h4": 16,
+        "h5": 13,
+        "h6": 10,
     }
 
 
 class HTML:
-    #----------------------------------------------------------------------------------------------
+    # ----------------------------------------------------------------------------------------------
     """
-    List of supported HTML tags and attrs 
+    List of supported HTML tags and attrs
     """
-    class Tag():
-        BR = 'br'
-        UL = 'ul'
-        OL = 'ol'
-        LI = 'li'
-        IMG = 'img'
-        A = 'a'
-        B = 'b'
-        STRONG = 'strong'
-        I = 'i'
-        EM = 'em'
-        U = 'u'
-        MARK = 'mark'
-        SPAN = 'span'
-        DIV = 'div'
-        P = 'p'
-        PRE = 'pre'
-        CODE = 'code'
-        H1 = 'h1'
-        H2 = 'h2'
-        H3 = 'h3'
-        H4 = 'h4'
-        H5 = 'h5'
-        H6 = 'h6'
-        TABLE = "table"
-        TR = "tr"
-        TH = "th"
-        TD = "td"
 
-    class Attrs():
-        STYLE = 'style'
-        HREF ='href'
-        SRC = 'src'
-        WIDTH = 'width'
-        HEIGHT = 'height'
-        TYPE = 'type'
+    class Tag:
+        BR = "br"
+        UL = "ul"
+        OL = "ol"
+        LI = "li"
+        IMG = "img"
+        A = "a"
+        B = "b"
+        STRONG = "strong"
+        I = "i"
+        EM = "em"
+        U = "u"
+        MARK = "mark"
+        SPAN = "span"
+        DIV = "div"
+        P = "p"
+        PRE = "pre"
+        CODE = "code"
+        H1 = "h1"
+        H2 = "h2"
+        H3 = "h3"
+        H4 = "h4"
+        H5 = "h5"
+        H6 = "h6"
 
-    class TypeOrderedList():
-        _1 = '1'
-        a = 'a'
-        A = 'A'
+    class Attrs:
+        STYLE = "style"
+        HREF = "href"
+        SRC = "src"
+        WIDTH = "width"
+        HEIGHT = "height"
+        TYPE = "type"
 
-    class Style():
-        COLOR = 'color'
-        BACKGROUD_COLOR = 'background-color'
-        FONT_FAMILY = 'font-family'
-        FONT_SIZE = 'font-size'
-        TEXT_ALIGN = 'text-align'
-        TEXT_DECORATION = 'text-decoration'
+    class TypeOrderedList:
+        _1 = "1"
+        a = "a"
+        A = "A"
 
-    class StyleTextDecoration():
-        UNDERLINE = 'underline'
-        LINE_THROUGH = 'line-through'
+    class Style:
+        COLOR = "color"
+        BACKGROUND_COLOR = "background-color"
+        FONT_FAMILY = "font-family"
+        FONT_SIZE = "font-size"
+        TEXT_ALIGN = "text-align"
+        TEXT_DECORATION = "text-decoration"
+
+    class StyleTextDecoration:
+        UNDERLINE = "underline"
+        LINE_THROUGH = "line-through"
 
     HEADING_TAGS = (
         Tag.H1,
@@ -103,7 +101,7 @@ class HTML:
         Tag.P,
         Tag.PRE,
         Tag.CODE,
-    ) 
+    )
 
     NEW_LINE_TAGS = HEADING_TAGS + (
         Tag.UL,
@@ -112,9 +110,7 @@ class HTML:
         Tag.P,
         Tag.PRE,
         Tag.CODE,
-        Tag.TABLE,
-        Tag.TR,
-    )  
+    )
 
     STYLE_TAGS = TEXT_ALIGN_TAGS + (
         Tag.A,
@@ -125,23 +121,22 @@ class HTML:
         Tag.U,
         Tag.MARK,
         Tag.SPAN,
-        Tag.TD,
-        Tag.TH,
     )
 
 
-
-#--------------------------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------------------
 # Text widget defs
 
-class WCfg():
+
+class WCfg:
     KEY = "config"
     BACKGROUND = "background"
     FOREGROUND = "foreground"
     JUSTIFY = "justify"
     TABS = "tabs"
 
-class Fnt():
+
+class Fnt:
     KEY = "font"
     FAMILY = "family"
     SIZE = "size"
@@ -150,99 +145,104 @@ class Fnt():
     UNDERLINE = "underline"
     OVERSTRIKE = "overstrike"
 
-class Bind():
+
+class Bind:
     KEY = "bind"
     LINK = "link"
     IMAGE = "image"
 
-class WTag():
+
+class WTag:
     START_INDEX = "start_index"
     END_INDEX = "end_index"
 
+
 DEFAULT_STACK = {
-    WCfg.KEY:{
-        WCfg.BACKGROUND:[],
-        WCfg.FOREGROUND:[("__DEFAULT__", "black")],
-        WCfg.JUSTIFY:[("__DEFAULT__", 'left')],
-        WCfg.TABS:[("__DEFAULT__", ())],
+    WCfg.KEY: {
+        WCfg.BACKGROUND: [],
+        WCfg.FOREGROUND: [("__DEFAULT__", "black")],
+        WCfg.JUSTIFY: [("__DEFAULT__", "left")],
+        WCfg.TABS: [("__DEFAULT__", ())],
     },
-    Fnt.KEY:{
-        Fnt.FAMILY:[],
-        Fnt.SIZE:[("__DEFAULT__", Defs.FONT_SIZE)],
-        Fnt.WEIGHT:[("__DEFAULT__", 'normal')],
-        Fnt.SLANT:[("__DEFAULT__", 'roman')],
-        Fnt.UNDERLINE:[("__DEFAULT__", False)],
-        Fnt.OVERSTRIKE:[("__DEFAULT__", False)],
+    Fnt.KEY: {
+        Fnt.FAMILY: [],
+        Fnt.SIZE: [("__DEFAULT__", Defs.FONT_SIZE)],
+        Fnt.WEIGHT: [("__DEFAULT__", "normal")],
+        Fnt.SLANT: [("__DEFAULT__", "roman")],
+        Fnt.UNDERLINE: [("__DEFAULT__", False)],
+        Fnt.OVERSTRIKE: [("__DEFAULT__", False)],
     },
-    Bind.KEY:{
-        Bind.LINK:[("__DEFAULT__", None)],
+    Bind.KEY: {
+        Bind.LINK: [("__DEFAULT__", None)],
     },
 }
 
-#__________________________________________________________________________________________________
+
+# __________________________________________________________________________________________________
 # functions
 def get_existing_font(font_families):
-    #------------------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------------------
     try:
-        return next(filter(lambda f: f.lower() in (f.lower() for f in font.families()), font_families))
+        return next(
+            filter(
+                lambda f: f.lower() in (f.lower() for f in font.families()),
+                font_families,
+            )
+        )
     except:
         return "TkTextFont"
 
 
-#__________________________________________________________________________________________________
+# __________________________________________________________________________________________________
 # classes
-class HLinkSlot():
-    #----------------------------------------------------------------------------------------------
+class HLinkSlot:
+    # ----------------------------------------------------------------------------------------------
 
     def __init__(self, w, tag_name, url):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         self._w = w
         self.tag_name = tag_name
         self.URL = url
 
     def call(self, event):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         webbrowser.open(self.URL)
         self._w.tag_config(self.tag_name, foreground="purple")
 
     def enter(self, event):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         self._w.config(cursor="hand2")
 
     def leave(self, event):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         self._w.config(cursor="")
 
 
-
-
-class ListTag():
-    #----------------------------------------------------------------------------------------------
-    def __init__(self, ordered:bool, list_type=None):
-        #------------------------------------------------------------------------------------------
+class ListTag:
+    # ----------------------------------------------------------------------------------------------
+    def __init__(self, ordered: bool, list_type=None):
+        # ------------------------------------------------------------------------------------------
         self.ordered = ordered
         self.type = list_type
         self.index = 0
 
     def add(self):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         if self.ordered:
             self.index += 1
 
     def line_index(self):
-        #------------------------------------------------------------------------------------------
-        if self.ordered:
-            if self.type == HTML.TypeOrderedList._1:
-                return str(self.index)
-            elif self.type == HTML.TypeOrderedList.a:
-                return self._index_to_str(self.index).lower()
-            elif self.type == HTML.TypeOrderedList.A:
-                return self._index_to_str(self.index).upper()
-        else:
+        if not self.ordered:
             return chr(8226)
-    
+        if self.type == HTML.TypeOrderedList._1:
+            return str(self.index)
+        elif self.type == HTML.TypeOrderedList.a:
+            return self._index_to_str(self.index).lower()
+        elif self.type == HTML.TypeOrderedList.A:
+            return self._index_to_str(self.index).upper()
+
     def _index_to_str(self, index):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         prefix = ""
         if index > 26:
             prefix = self._index_to_str(index // 26)
@@ -251,12 +251,11 @@ class ListTag():
         return prefix + chr(0x60 + index)
 
 
-
 class HTMLTextParser(HTMLParser):
-    #----------------------------------------------------------------------------------------------
+    # ----------------------------------------------------------------------------------------------
 
     def __init__(self):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         super().__init__()
         # set list tabs
         self.cached_images = {}
@@ -264,16 +263,15 @@ class HTMLTextParser(HTMLParser):
         self.DEFAULT_TEXT_FONT_FAMILY = get_existing_font(Defs.DEFAULT_TEXT_FONT_FAMILY)
         self.PREFORMATTED_FONT_FAMILY = get_existing_font(Defs.PREFORMATTED_FONT_FAMILY)
 
-
     def _parse_attrs(self, attrs):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         attrs_dict = {
-            HTML.Attrs.STYLE:{},
-            HTML.Attrs.HREF:None,
-            HTML.Attrs.SRC:None,
-            HTML.Attrs.WIDTH:None,
-            HTML.Attrs.HEIGHT:None,
-            HTML.Attrs.TYPE:None,
+            HTML.Attrs.STYLE: {},
+            HTML.Attrs.HREF: None,
+            HTML.Attrs.SRC: None,
+            HTML.Attrs.WIDTH: None,
+            HTML.Attrs.HEIGHT: None,
+            HTML.Attrs.TYPE: None,
         }
         for k, v in attrs:
             k = k.lower()
@@ -285,18 +283,19 @@ class HTMLTextParser(HTMLParser):
                         attrs_dict[HTML.Attrs.STYLE][p_key] = p_value
                     except:
                         pass
-            elif k in (HTML.Attrs.HREF, HTML.Attrs.SRC, HTML.Attrs.WIDTH, HTML.Attrs.HEIGHT, HTML.Attrs.TYPE):
+            elif k in (
+                HTML.Attrs.HREF,
+                HTML.Attrs.SRC,
+                HTML.Attrs.WIDTH,
+                HTML.Attrs.HEIGHT,
+                HTML.Attrs.TYPE,
+            ):
                 attrs_dict[k] = v
         return attrs_dict
 
-
     def _w_tags_add(self):
-        #------------------------------------------------------------------------------------------
-        tag = {
-            WCfg.KEY:{},
-            Fnt.KEY:{},
-            Bind.KEY:{}
-        }
+        # ------------------------------------------------------------------------------------------
+        tag = {WCfg.KEY: {}, Fnt.KEY: {}, Bind.KEY: {}}
 
         for k1 in (WCfg.KEY, Fnt.KEY, Bind.KEY):
             for k2 in DEFAULT_STACK[k1]:
@@ -304,9 +303,8 @@ class HTMLTextParser(HTMLParser):
 
         self._w_tags[self._w.index("end-1c")] = tag
 
-
     def _stack_get_main_key(self, key):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         if key in WCfg.__dict__.values():
             main_key = WCfg.KEY
         elif key in Fnt.__dict__.values():
@@ -315,23 +313,21 @@ class HTMLTextParser(HTMLParser):
             main_key = Bind.KEY
         else:
             raise ValueError("key %s doesn't exists" % key)
-        
+
         return main_key
 
-
     def _stack_add(self, tag, key, value=None):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         main_key = self._stack_get_main_key(key)
-        
+
         if value is None:
             # if value is none, add the previous value
-            value =  self.stack[main_key][key][-1][1]
-        
+            value = self.stack[main_key][key][-1][1]
+
         self.stack[main_key][key].append((tag, value))
 
-
     def _stack_index(self, tag, key):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         main_key = self._stack_get_main_key(key)
         index = None
         for i, v in enumerate(self.stack[main_key][key]):
@@ -340,38 +336,42 @@ class HTMLTextParser(HTMLParser):
 
         return index
 
-
     def _stack_pop(self, tag, key):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         main_key = self._stack_get_main_key(key)
 
         index = None
         if len(self.stack[main_key][key]) > 1:
             index = self._stack_index(tag, key)
-        
+
         if index is not None:
             return self.stack[main_key][key].pop(index)[1]
 
-
     def _parse_styles(self, tag, attrs):
-        #------------------------------------------------------------------------------------------
-        #-------------------------------------------------------------------------------- [ COLOR ]
+        # ------------------------------------------------------------------------------------------
+        # -------------------------------------------------------------------------------- [ COLOR ]
         if HTML.Style.COLOR in attrs[HTML.Attrs.STYLE].keys():
-            self._stack_add(tag, WCfg.FOREGROUND, attrs[HTML.Attrs.STYLE][HTML.Style.COLOR])
+            self._stack_add(
+                tag, WCfg.FOREGROUND, attrs[HTML.Attrs.STYLE][HTML.Style.COLOR]
+            )
         elif tag == HTML.Tag.A and attrs[HTML.Attrs.HREF]:
             self._stack_add(tag, WCfg.FOREGROUND, "blue")
         else:
             self._stack_add(tag, WCfg.FOREGROUND)
 
-        #---------------------------------------------------------------------- [ BACKGROUD_COLOR ]
-        if HTML.Style.BACKGROUD_COLOR in attrs[HTML.Attrs.STYLE].keys():
-            self._stack_add(tag, WCfg.BACKGROUND, attrs[HTML.Attrs.STYLE][HTML.Style.BACKGROUD_COLOR])
+        # ---------------------------------------------------------------------- [ BACKGROUND_COLOR ]
+        if HTML.Style.BACKGROUND_COLOR in attrs[HTML.Attrs.STYLE].keys():
+            self._stack_add(
+                tag,
+                WCfg.BACKGROUND,
+                attrs[HTML.Attrs.STYLE][HTML.Style.BACKGROUND_COLOR],
+            )
         elif tag == HTML.Tag.MARK:
             self._stack_add(tag, WCfg.BACKGROUND, "yellow")
         else:
             self._stack_add(tag, WCfg.BACKGROUND)
 
-        #-------------------------------------------------------------------------- [ FONT_FAMILY ]
+        # -------------------------------------------------------------------------- [ FONT_FAMILY ]
         # font family
         if HTML.Style.FONT_FAMILY in attrs[HTML.Attrs.STYLE].keys():
             font_family = Defs.DEFAULT_TEXT_FONT_FAMILY
@@ -386,7 +386,7 @@ class HTMLTextParser(HTMLParser):
         else:
             self._stack_add(tag, Fnt.FAMILY)
 
-        #---------------------------------------------------------------------------- [ FONT_SIZE ]
+        # ---------------------------------------------------------------------------- [ FONT_SIZE ]
         if HTML.Style.FONT_SIZE in attrs[HTML.Attrs.STYLE].keys():
             size = Defs.FONT_SIZE
             if attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE].endswith("px"):
@@ -394,89 +394,106 @@ class HTMLTextParser(HTMLParser):
                     size = int(attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE][:-2])
             elif attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE].endswith(r"%"):
                 if attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE][:-1].isdigit():
-                    size = int((int(attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE][:-1]) * Defs.FONT_SIZE)/100)
+                    size = int(
+                        (
+                            int(attrs[HTML.Attrs.STYLE][HTML.Style.FONT_SIZE][:-1])
+                            * Defs.FONT_SIZE
+                        )
+                        / 100
+                    )
             self._stack_add(tag, Fnt.SIZE, size)
-        elif tag.startswith('h') and len(tag) == 2:
+        elif tag.startswith("h") and len(tag) == 2:
             self._stack_add(tag, Fnt.SIZE, Defs.HEADINGS_FONT_SIZE[tag])
         else:
             self._stack_add(tag, Fnt.SIZE)
 
-        #--------------------------------------------------------------------------- [ TEXT_ALIGN ]
-        if HTML.Style.TEXT_ALIGN in attrs[HTML.Attrs.STYLE].keys() and tag in HTML.TEXT_ALIGN_TAGS:
-            self._stack_add(tag, WCfg.JUSTIFY, attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_ALIGN])
+        # --------------------------------------------------------------------------- [ TEXT_ALIGN ]
+        if (
+            HTML.Style.TEXT_ALIGN in attrs[HTML.Attrs.STYLE].keys()
+            and tag in HTML.TEXT_ALIGN_TAGS
+        ):
+            self._stack_add(
+                tag, WCfg.JUSTIFY, attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_ALIGN]
+            )
         else:
             self._stack_add(tag, WCfg.JUSTIFY)
 
-        #---------------------------------------------------------------------- [ TEXT_DECORATION ]
+        # ---------------------------------------------------------------------- [ TEXT_DECORATION ]
         if HTML.Style.TEXT_DECORATION in attrs[HTML.Attrs.STYLE].keys():
             if tag == HTML.Tag.STRONG:
                 self._stack_add(tag, Fnt.UNDERLINE, False)
                 self._stack_add(tag, Fnt.OVERSTRIKE, False)
-            elif HTML.StyleTextDecoration.UNDERLINE in attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_DECORATION]:
+            elif (
+                HTML.StyleTextDecoration.UNDERLINE
+                in attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_DECORATION]
+            ):
                 self._stack_add(tag, Fnt.UNDERLINE, True)
                 self._stack_add(tag, Fnt.OVERSTRIKE, False)
-            elif HTML.StyleTextDecoration.LINE_THROUGH in attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_DECORATION]:
+            elif (
+                HTML.StyleTextDecoration.LINE_THROUGH
+                in attrs[HTML.Attrs.STYLE][HTML.Style.TEXT_DECORATION]
+            ):
                 self._stack_add(tag, Fnt.UNDERLINE, False)
                 self._stack_add(tag, Fnt.OVERSTRIKE, True)
             else:
                 self._stack_add(tag, Fnt.UNDERLINE)
                 self._stack_add(tag, Fnt.OVERSTRIKE)
+        elif tag == HTML.Tag.A and attrs[HTML.Attrs.HREF]:
+            self._stack_add(tag, Fnt.UNDERLINE, True)
+            self._stack_add(tag, Fnt.OVERSTRIKE, False)
+        elif tag == HTML.Tag.U:
+            self._stack_add(tag, Fnt.UNDERLINE, True)
+            self._stack_add(tag, Fnt.OVERSTRIKE, False)
         else:
-            if tag == HTML.Tag.A and attrs[HTML.Attrs.HREF]:
-                self._stack_add(tag, Fnt.UNDERLINE, True)
-                self._stack_add(tag, Fnt.OVERSTRIKE, False)
-            elif tag == HTML.Tag.U:
-                self._stack_add(tag, Fnt.UNDERLINE, True)
-                self._stack_add(tag, Fnt.OVERSTRIKE, False)
-            else:
-                self._stack_add(tag, Fnt.UNDERLINE)
-                self._stack_add(tag, Fnt.OVERSTRIKE)
-
+            self._stack_add(tag, Fnt.UNDERLINE)
+            self._stack_add(tag, Fnt.OVERSTRIKE)
 
     def handle_starttag(self, tag, attrs):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         tag = tag.lower()
         attrs = self._parse_attrs(attrs)
 
         if tag in HTML.STYLE_TAGS:
-            #---------------------------------------------------------------------- [ STYLED_TAGS ]
+            # ---------------------------------------------------------------------- [ STYLED_TAGS ]
             self._parse_styles(tag, attrs)
 
             if tag == HTML.Tag.B or tag == HTML.Tag.STRONG or tag in HTML.HEADING_TAGS:
                 self._stack_add(tag, Fnt.WEIGHT, "bold")
 
-            elif tag == HTML.Tag.I or tag == HTML.Tag.EM:
+            elif tag in [HTML.Tag.I, HTML.Tag.EM]:
                 self._stack_add(tag, Fnt.SLANT, "italic")
 
             elif tag == HTML.Tag.A:
                 self._stack_add(tag, Bind.LINK, attrs[HTML.Attrs.HREF])
 
             elif tag == HTML.Tag.OL:
-                #---------------------------------------------------------------- [ ORDERED_LISTS ]
-                if attrs[HTML.Attrs.TYPE] and attrs[HTML.Attrs.TYPE] in HTML.TypeOrderedList.__dict__.values():
+                # ---------------------------------------------------------------- [ ORDERED_LISTS ]
+                if (
+                    attrs[HTML.Attrs.TYPE]
+                    and attrs[HTML.Attrs.TYPE] in HTML.TypeOrderedList.__dict__.values()
+                ):
                     list_type = attrs[HTML.Attrs.TYPE]
                 else:
                     list_type = HTML.TypeOrderedList._1
                 self.list_tags.append(ListTag(ordered=True, list_type=list_type))
-                
+
                 tabs = []
                 for i in range(len(self.list_tags)):
                     offset = 30 * (i + 1)
-                    tabs += [offset, tk.RIGHT, offset+5, tk.LEFT ]
+                    tabs += [offset, tk.RIGHT, offset + 5, tk.LEFT]
                 self._stack_add(tag, WCfg.TABS, tabs)
 
             elif tag == HTML.Tag.UL:
-                #-------------------------------------------------------------- [ UNORDERED_LISTS ]
+                # -------------------------------------------------------------- [ UNORDERED_LISTS ]
                 self.list_tags.append(ListTag(ordered=False))
 
                 tabs = []
                 for i in range(len(self.list_tags)):
                     offset = 30 * (i + 1)
-                    tabs += [offset, tk.RIGHT, offset+5, tk.LEFT ]
+                    tabs += [offset, tk.RIGHT, offset + 5, tk.LEFT]
                 self._stack_add(tag, WCfg.TABS, tabs)
 
             elif tag == HTML.Tag.LI:
-                #------------------------------------------------------------------ [ LISTS_LINES ]
                 level = len(self.list_tags)
                 if level:
                     self.list_tags[-1].add()
@@ -486,32 +503,31 @@ class HTMLTextParser(HTMLParser):
 
                     line_index = self.list_tags[-1].line_index()
                     if self.list_tags[-1].ordered:
-                        line_index = "\t" + "\t\t" * (level-1) + line_index + ".\t"
+                        line_index = "\t" + "\t\t" * (level - 1) + line_index + ".\t"
                     else:
-                        line_index = "\t" + "\t\t" * (level-1) + line_index + "\t"
-                    
+                        line_index = "\t" + "\t\t" * (level - 1) + line_index + "\t"
+
                     self._stack_add(tag, Fnt.UNDERLINE, False)
                     self._stack_add(tag, Fnt.OVERSTRIKE, False)
                     self._w_tags_add()
                     self._w.insert(tk.INSERT, line_index)
                     self._stack_pop(tag, Fnt.UNDERLINE)
                     self._stack_pop(tag, Fnt.OVERSTRIKE)
-                    
-            elif tag == HTML.Tag.TD or tag == HTML.Tag.TD:
-                    self._w.insert(tk.INSERT, "\t")
 
         elif tag == HTML.Tag.IMG and attrs[HTML.Attrs.SRC]:
-            #-------------------------------------------------------------------- [ UNSTYLED_TAGS ]
+            # -------------------------------------------------------------------- [ UNSTYLED_TAGS ]
             image = None
-            print(attrs[HTML.Attrs.SRC] , self.cached_images)
-            if attrs[HTML.Attrs.SRC].startswith(("https://" , "ftp://" , "http://")):
+            # print(attrs[HTML.Attrs.SRC] , self.cached_images)
+            if attrs[HTML.Attrs.SRC].startswith(("https://", "ftp://", "http://")):
                 if attrs[HTML.Attrs.SRC] in self.cached_images.keys():
                     image = deepcopy(self.cached_images[attrs[HTML.Attrs.SRC]])
                 else:
                     try:
-                        image = Image.open(BytesIO(requests.get(attrs[HTML.Attrs.SRC]).content))
+                        image = Image.open(
+                            BytesIO(requests.get(attrs[HTML.Attrs.SRC]).content)
+                        )
                         self.cached_images[attrs[HTML.Attrs.SRC]] = deepcopy(image)
-                    except :
+                    except:
                         pass
 
             if attrs[HTML.Attrs.SRC] in self.cached_images.keys():
@@ -532,109 +548,96 @@ class HTMLTextParser(HTMLParser):
                 if resize:
                     image = image.resize((width, height), Image.ANTIALIAS)
                 self.images.append(ImageTk.PhotoImage(image))
-                self._w.image_create(tk.INSERT, image=self.images[-1]) 
-                
-        elif tag == HTML.Tag.TABLE:
-                tabs = []
-                for i in range(30): # HF waslen(self.list_tags)):
-                    offset = 40 * (i + 1)
-                    tabs += [offset, tk.LEFT ]
-                self._stack_add(tag, WCfg.TABS, tabs)
-            
+                self._w.image_create(tk.INSERT, image=self.images[-1])
 
         if self.strip:
-            #------------------------------------------------------------------------ [ NEW_LINES ]
             if tag == HTML.Tag.BR:
                 self._insert_new_line()
             else:
                 self.html_tags.append(tag)
 
-            if tag in HTML.NEW_LINE_TAGS and self.strip and self._w.index("end-1c") != "1.0":
-                if tag in (HTML.Tag.DIV,):
-                    self._insert_new_line()
-                elif tag in (HTML.Tag.UL, HTML.Tag.OL):
-                    if len(self.list_tags) == 1:
-                        self._insert_new_line(double=True)
-                    else:
-                        self._insert_new_line(double=False)
-                else:       
+        if (
+            tag in HTML.NEW_LINE_TAGS
+            and self.strip
+            and self._w.index("end-1c") != "1.0"
+        ):
+            if tag in (HTML.Tag.DIV,):
+                self._insert_new_line()
+            elif tag in (HTML.Tag.UL, HTML.Tag.OL):
+                if len(self.list_tags) == 1:
                     self._insert_new_line(double=True)
+                else:
+                    self._insert_new_line(double=False)
+            else:
+                self._insert_new_line(double=True)
 
         self._w_tags_add()
 
-
     def handle_charref(self, data):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         try:
             char = chr(int(data))
             self._w.insert(tk.INSERT, char)
         except:
             pass
 
-
     def _insert_new_line(self, double=False):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         self._remove_last_space()
         if self._w.get("end-3c", "end-1c") == "\n\n":
             pass
         elif self._w.get("end-2c", "end-1c") == "\n":
             if double:
                 self._w.insert(tk.INSERT, "\n")
+        elif double:
+            self._w.insert(tk.INSERT, "\n\n")
         else:
-            if double:
-                self._w.insert(tk.INSERT, "\n\n")
-            else:
-                self._w.insert(tk.INSERT, "\n")
-
+            self._w.insert(tk.INSERT, "\n")
 
     def _text_rstrip(self):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         for _ in range(3):
             if self._w.get("end-2c", "end-1c") in (" ", "\n"):
                 self._w.delete("end-2c", "end-1c")
 
-
     def _remove_last_space(self):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         if self._w.get("end-2c", "end-1c") == " ":
             self._w.delete("end-2c", "end-1c")
 
-
     def _remove_multi_spaces(self, data):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         data = data.replace("  ", " ")
         if "  " in data:
             data = self._remove_multi_spaces(data)
         return data
 
-
     def handle_data(self, data):
-        #------------------------------------------------------------------------------------------
-        if self.strip:
-            if len(self.html_tags) and self.html_tags[-1] in (HTML.Tag.PRE, HTML.Tag.CODE):
-                pass
-            elif not data.strip():
+        if len(self.html_tags) and self.html_tags[-1] in (HTML.Tag.PRE, HTML.Tag.CODE):
+            pass
+        elif not data.strip():
+            if self.strip:
                 data = ""
-            else:
-                # left strip
-                if self._w.index("end-1c").endswith(".0"):
-                    data = data.lstrip()
-                elif self._w.get("end-2c", "end-1c") == " ":
-                    data = data.lstrip()
+        elif self.strip:
+            # left strip
+            if self._w.index("end-1c").endswith(".0"):
+                data = data.lstrip()
+            elif self._w.get("end-2c", "end-1c") == " ":
+                data = data.lstrip()
 
-                data = data.replace("\n", " ").replace("\t", " ")
-                data = data + " "
-                data = self._remove_multi_spaces(data)
-                if len(self.html_tags):
-                    level = len(self.list_tags)
-                    if self.html_tags[-1] in (HTML.Tag.UL, HTML.Tag.OL):
-                        self._w.insert(tk.INSERT, "\t" * 2 * level)
+            data = data.replace("\n", " ").replace("\t", " ")
+            data = f"{data} "
+            data = self._remove_multi_spaces(data)
+            if len(self.html_tags) and self.html_tags[-1] in (
+                HTML.Tag.UL,
+                HTML.Tag.OL,
+            ):
+                self._w.insert(tk.INSERT, "\t" * 2 * len(self.list_tags))
 
         self._w.insert(tk.INSERT, data)
 
-
     def handle_endtag(self, tag):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         tag = tag.lower()
 
         try:
@@ -644,7 +647,6 @@ class HTMLTextParser(HTMLParser):
             pass
 
         if tag in HTML.STYLE_TAGS:
-
             self._stack_pop(tag, WCfg.FOREGROUND)
             self._stack_pop(tag, WCfg.BACKGROUND)
             self._stack_pop(tag, WCfg.JUSTIFY)
@@ -656,13 +658,13 @@ class HTMLTextParser(HTMLParser):
             if tag == HTML.Tag.B or tag == HTML.Tag.STRONG or tag in HTML.HEADING_TAGS:
                 self._stack_pop(tag, Fnt.WEIGHT)
 
-            elif tag == HTML.Tag.I or tag == HTML.Tag.EM:
+            elif tag in [HTML.Tag.I, HTML.Tag.EM]:
                 self._stack_pop(tag, Fnt.SLANT)
 
             elif tag == HTML.Tag.A:
                 self._stack_pop(tag, Bind.LINK)
 
-            elif tag == HTML.Tag.OL or tag == HTML.Tag.UL:
+            elif tag in [HTML.Tag.OL, HTML.Tag.UL]:
                 if len(self.list_tags):
                     self.list_tags = self.list_tags[:-1]
 
@@ -680,9 +682,8 @@ class HTMLTextParser(HTMLParser):
             else:
                 self._insert_new_line(double=True)
 
-
     def _w_tags_apply_all(self):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         # update indexes
         if self.strip:
             self._text_rstrip()
@@ -695,24 +696,29 @@ class HTMLTextParser(HTMLParser):
         # add tags
         self.hlink_slots = []
         for key, tag in self._w_tags.items():
-            if "config" in tag: # HF change to change justify to fill for tkinter
+            if "config" in tag: # HF change justify to left for tkinter (only supports left, right, center)
                 if tag["config"].get("justify") == "justify":
                     tag["config"]["justify"] = "left"
             self._w.tag_add(key, tag[WTag.START_INDEX], tag[WTag.END_INDEX])
             self._w.tag_config(key, font=font.Font(**tag[Fnt.KEY]), **tag[WCfg.KEY])
             if tag[Bind.KEY][Bind.LINK]:
-                self.hlink_slots.append(HLinkSlot(self._w, key, tag[Bind.KEY][Bind.LINK]))
+                self.hlink_slots.append(
+                    HLinkSlot(self._w, key, tag[Bind.KEY][Bind.LINK])
+                )
                 self._w.tag_bind(key, "<Button-1>", self.hlink_slots[-1].call)
                 self._w.tag_bind(key, "<Leave>", self.hlink_slots[-1].leave)
                 self._w.tag_bind(key, "<Enter>", self.hlink_slots[-1].enter)
-        
 
     def w_set_html(self, w, html, strip):
-        #------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------
         self._w = w
         self.stack = deepcopy(DEFAULT_STACK)
-        self.stack[WCfg.KEY][WCfg.BACKGROUND].append(("__DEFAULT__", self._w.cget("background")))
-        self.stack[Fnt.KEY][Fnt.FAMILY].append(("__DEFAULT__", self.DEFAULT_TEXT_FONT_FAMILY))
+        self.stack[WCfg.KEY][WCfg.BACKGROUND].append(
+            ("__DEFAULT__", self._w.cget("background"))
+        )
+        self.stack[Fnt.KEY][Fnt.FAMILY].append(
+            ("__DEFAULT__", self.DEFAULT_TEXT_FONT_FAMILY)
+        )
         self._w_tags = OrderedDict()
         self.html_tags = []
         self.images = []


### PR DESCRIPTION
Tkinter crashes on styles calling for text-align: justify, change justify into left.

Example of crashing style: `<div style="margin-top:10pt;padding-left:4.5pt;text-align:justify">`