### PR TITLE
Refactoring and another fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The widgets behaviour is similar to the PyQt5 text widgets (see the [PyQt5 HTML 
 
 ## Requirements
 
-- [Python 3.4 or later](https://www.python.org/downloads/) with tcl/tk support
+- [Python 3.6 or later](https://www.python.org/downloads/) with tcl/tk support
 - [Pillow 5.3.0](https://github.com/python-pillow/Pillow)
 - requests
 
@@ -138,7 +138,7 @@ Where is possibile, I hope to add more HTML support in the next releases.
 | ul       | style              | bullet glyphs only                     |
 | table,tr,th,td | - | basic support|
 
-> Note: All styles are not supported; 
+> Note: All styles are not supported;
 > align with justify is not supported; it falls back to left align
 
 ## License

--- a/example.py
+++ b/example.py
@@ -6,45 +6,54 @@ root.geometry("780x640")
 html_label = HTMLScrolledText(
     root,
     html="""
-                       <h1 style="color: red; text-align: center"> Hello World </h1>
-                       <h2> Smaller </h2>
-                       <h3> Little Smaller </h3>
-                       <h4> Little Little Smaller </h4>
-                       <h5> Little Little Little Smaller </h5>
-                       <h6> Little Little Little Little Smaller </h6>
-                       <strong>This is a bold text</strong>
-                       <em>This is a italic text</em>
-                       <img src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"></img>
-                       <ul>
-                        <li> One </li>
-                        <ul>
-                            <li> One.Zero </li>
-                        </ul>
-                        <li> Two </li>
-                        <li> Three </li>
-                        <li> Four </li>
-                       </ul>
+      <h1 style="color: red; text-align: center"> Hello World </h1>
+      <h2> Smaller </h2>
+      <h3> Little Smaller </h3>
+      <h4> Little Little Smaller </h4>
+      <h5> Little Little Little Smaller </h5>
+      <h6> Little Little Little Little Smaller </h6>
+      <strong>This is a bold text</strong>
+      <em>This is a italic text</em>
+      <img src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"></img>
+      <ul>
+      <li> One </li>
+      <ul>
+          <li> One.Zero </li>
+      </ul>
+      <li> Two </li>
+      <li> Three </li>
+      <li> Four </li>
+      </ul>
 
-                       <h3> Paragraph </h3>
-                       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ut quam sapien. Maecenas porta tempus mauris sed ullamcorper. Nulla facilisi. Nulla facilisi. Mauris tristique ipsum et efficitur lobortis. Sed pharetra ipsum non lacinia dignissim. Ut condimentum vulputate sem eget scelerisque. Curabitur ornare augue enim, sed volutpat enim finibus id. </p>
+      <h3> Paragraph </h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ut quam sapien. Maecenas porta tempus mauris sed ullamcorper. Nulla facilisi. Nulla facilisi. Mauris tristique ipsum et efficitur lobortis. Sed pharetra ipsum non lacinia dignissim. Ut condimentum vulputate sem eget scelerisque. Curabitur ornare augue enim, sed volutpat enim finibus id. </p>
 
-<h3>Table</h3
-<table>
-    <tr>
-      <th>T Header 1</th>
-      <th>T Header 2</th>
-    </tr>
-    <tr>
-      <td>ABC</td>
-      <td>123</td>
-    </tr>
-    <tr>
-      <td>DEF</td>
-      <td>456</td>
-    </tr>
+      <h3>Table</h3
+      <table>
+          <tr>
+            <th>T Header 1</th>
+            <th>T Header 2</th>
+          </tr>
+          <tr>
+            <td>ABC</td>
+            <td>123</td>
+          </tr>
+          <tr>
+            <td>DEF</td>
+            <td>456</td>
+          </tr>
+      </table>
 
-</table>
-                       """,
+      <h3> Preformatted text, with spaces and newlines preserved </h3>
+      <pre style="font-family: Consolas; font-size: 80%">
+<b>Tags      Attributes          Notes</b>
+a         style, <span style="color: RoyalBlue">href         </span>-
+img       <u>src</u>, width, height  <i>experimental</i>
+ol        <span style="color: Tomato">style, type         </span>-
+ul        <i>style               </i>bullet glyphs only
+div       style               -
+      </pre>
+    """,
 )
 html_label.pack(fill="both", expand=True)
 html_label.fit_height()

--- a/example.py
+++ b/example.py
@@ -12,14 +12,18 @@ html_label = HTMLScrolledText(
       <h4> Little Little Smaller </h4>
       <h5> Little Little Little Smaller </h5>
       <h6> Little Little Little Little Smaller </h6>
-      <strong>This is a bold text</strong>
-      <em>This is a italic text</em>
+      <b>This is a Bold text</b><br/>
+      <strong>This is an Important text</strong><br/>
+      <i>This is a Italic text</i><br/>
+      <em>This is a Emphasized text</em><br/>
+      <em>This is a <strong>Strong Emphasized</strong>   text   </em>.<br/>
       <img src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"></img>
       <ul>
       <li> One </li>
-      <ul>
-          <li> One.Zero </li>
-      </ul>
+        <ul>
+            <li> One.Zero </li>
+            <li> One.One </li>
+        </ul>
       <li> Two </li>
       <li> Three </li>
       <li> Four </li>
@@ -31,20 +35,20 @@ html_label = HTMLScrolledText(
       <h3>Table</h3
       <table>
           <tr>
-            <th>T Header 1</th>
-            <th>T Header 2</th>
+            <th style="background-color: silver">T Header 1</th>
+            <th style="background-color: silver">T Header 2</th>
           </tr>
           <tr>
             <td>ABC</td>
-            <td>123</td>
+            <td><em>123</em></td>
           </tr>
           <tr>
             <td>DEF</td>
-            <td>456</td>
+            <td><i>456</i></td>
           </tr>
       </table>
 
-      <h3> Preformatted text, with spaces and newlines preserved </h3>
+      <h3> Preformatted text: spaces and newlines preserved </h3>
       <pre style="font-family: Consolas; font-size: 80%">
 <b>Tags      Attributes          Notes</b>
 a         style, <span style="color: RoyalBlue">href         </span>-
@@ -53,6 +57,17 @@ ol        <span style="color: Tomato">style, type         </span>-
 ul        <i>style               </i>bullet glyphs only
 div       style               -
       </pre>
+
+      <h3> Code: spaces and newlines ignored </h3>
+      <code style="font-family: Consolas; font-size: 80%">
+<b>Tags      Attributes          Notes</b><br/>
+a         style, <span style="color: RoyalBlue">href         </span>-
+img       <u>src</u>, width, height  <i>experimental</i>
+ol        <span style="color: Tomato">style, type         </span>-
+ul        <i>style               </i>bullet glyphs only
+div       style               -
+      </code>
+
     """,
 )
 html_label.pack(fill="both", expand=True)

--- a/tkhtmlview/__init__.py
+++ b/tkhtmlview/__init__.py
@@ -16,7 +16,7 @@ class _ScrolledText(tk.Text):
         self.vbar = tk.Scrollbar(self.frame)
         self.xscroll = tk.Scrollbar(self.frame, orient="horizontal")
 
-        if "xscroll" in kw.keys():
+        if "xscroll" in kw:
             # self.vbar.orient = "vertical"
             # print("vs")
             kw["xscrollcommand"] = self.xscroll.set
@@ -82,7 +82,6 @@ class HTMLScrolledText(_ScrolledText):
     def set_html(self, html, strip=True):
         """
         Set HTML widget text. If strip is enabled (default) it ignores spaces and new lines.
-
         """
         prev_state = self.cget("state")
         self.config(state=tk.NORMAL)

--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -199,7 +199,7 @@ def get_existing_font(font_families):
                 font_families,
             )
         )
-    except:
+    except Exception:
         return "TkTextFont"
 
 
@@ -322,7 +322,7 @@ class HTMLTextParser(HTMLParser):
         elif key in Bind.__dict__.values():
             main_key = Bind.KEY
         else:
-            raise ValueError("key %s doesn't exists" % key)
+            raise ValueError(f"key {key} doesn't exists")
 
         return main_key
 
@@ -467,10 +467,10 @@ class HTMLTextParser(HTMLParser):
             # ---------------------------------------------------------------------- [ STYLED_TAGS ]
             self._parse_styles(tag, attrs)
 
-            if tag == HTML.Tag.B or tag == HTML.Tag.STRONG or tag in HTML.HEADING_TAGS:
+            if tag in (HTML.Tag.B, HTML.Tag.STRONG) or tag in HTML.HEADING_TAGS:
                 self._stack_add(tag, Fnt.WEIGHT, "bold")
 
-            elif tag in [HTML.Tag.I, HTML.Tag.EM]:
+            elif tag in (HTML.Tag.I, HTML.Tag.EM):
                 self._stack_add(tag, Fnt.SLANT, "italic")
 
             elif tag == HTML.Tag.A:
@@ -524,7 +524,7 @@ class HTMLTextParser(HTMLParser):
                     self._stack_pop(tag, Fnt.UNDERLINE)
                     self._stack_pop(tag, Fnt.OVERSTRIKE)
 
-            elif tag == HTML.Tag.TH or tag == HTML.Tag.TD:
+            elif tag in (HTML.Tag.TH, HTML.Tag.TD):
                     self._w.insert(tk.INSERT, "\t")
 
         elif tag == HTML.Tag.IMG and attrs[HTML.Attrs.SRC]:
@@ -646,7 +646,7 @@ class HTMLTextParser(HTMLParser):
                 data = data.lstrip()
 
             data = data.replace("\n", " ").replace("\t", " ")
-            data = f"{data} "
+            data = f"{data} " # FIXME: attaching a space in blind is wrong
             data = self._remove_multi_spaces(data)
             if len(self.html_tags) and self.html_tags[-1] in (
                 HTML.Tag.UL,
@@ -678,13 +678,13 @@ class HTMLTextParser(HTMLParser):
             if tag == HTML.Tag.B or tag == HTML.Tag.STRONG or tag in HTML.HEADING_TAGS:
                 self._stack_pop(tag, Fnt.WEIGHT)
 
-            elif tag in [HTML.Tag.I, HTML.Tag.EM]:
+            elif tag in (HTML.Tag.I, HTML.Tag.EM):
                 self._stack_pop(tag, Fnt.SLANT)
 
             elif tag == HTML.Tag.A:
                 self._stack_pop(tag, Bind.LINK)
 
-            elif tag in [HTML.Tag.OL, HTML.Tag.UL]:
+            elif tag in (HTML.Tag.OL, HTML.Tag.UL):
                 if len(self.list_tags):
                     self.list_tags = self.list_tags[:-1]
 

--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -523,7 +523,7 @@ class HTMLTextParser(HTMLParser):
                     self._w.insert(tk.INSERT, line_index)
                     self._stack_pop(tag, Fnt.UNDERLINE)
                     self._stack_pop(tag, Fnt.OVERSTRIKE)
-                    
+
             elif tag == HTML.Tag.TH or tag == HTML.Tag.TD:
                     self._w.insert(tk.INSERT, "\t")
 
@@ -562,14 +562,14 @@ class HTMLTextParser(HTMLParser):
                     image = image.resize((width, height), Image.ANTIALIAS)
                 self.images.append(ImageTk.PhotoImage(image))
                 self._w.image_create(tk.INSERT, image=self.images[-1])
-                
+
         elif tag == HTML.Tag.TABLE:
                 tabs = []
                 for i in range(30): # HF was len(self.list_tags)):
                     offset = 40 * (i + 1)
                     tabs += [offset, tk.LEFT ]
                 self._stack_add(tag, WCfg.TABS, tabs)
-            
+
         if self.strip:
             if tag == HTML.Tag.BR:
                 self._insert_new_line()
@@ -633,7 +633,7 @@ class HTMLTextParser(HTMLParser):
         return data
 
     def handle_data(self, data):
-        if len(self.html_tags) and self.html_tags[-1] in (HTML.Tag.PRE, HTML.Tag.CODE):
+        if HTML.Tag.PRE in self.html_tags or HTML.Tag.CODE in self.html_tags:
             pass
         elif not data.strip():
             if self.strip:

--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -633,7 +633,7 @@ class HTMLTextParser(HTMLParser):
         return data
 
     def handle_data(self, data):
-        if HTML.Tag.PRE in self.html_tags or HTML.Tag.CODE in self.html_tags:
+        if HTML.Tag.PRE in self.html_tags:
             pass
         elif not data.strip():
             if self.strip:

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.0"
+VERSION = "0.2.1"


### PR DESCRIPTION
First of all - some of Sourcery linter finding has been corrected.
I also changed the minimal required Python version in the README from 3.4 to 3.6 (f-strings were used in the code anyway).

In the last commit I only changed the way of checking if current tag is in CODE or PRE block, but it appears that only PRE shall be checked - the CODE block, according to w3schools, should ignore newlines and multiple spaces just like the regular paragraph P, so I removed it from the condition and updated the example.py, so the result looks identical to those presented on w3schools.

Another thing is line 649 of `handle_data()` - not sure why the space is appended in blind to the data. Now, when STRONG, SPAN or another attribute is used, it is impossible to glue two parts of text, because of this extra space is always inserted.