### PR TITLE
Update required Pillow version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The widgets behaviour is similar to the PyQt5 text widgets (see the [PyQt5 HTML 
 ## Requirements
 
 - [Python 3.6 or later](https://www.python.org/downloads/) with tcl/tk support
-- [Pillow 5.3.0](https://github.com/python-pillow/Pillow)
+- [Pillow 10.0.0](https://github.com/python-pillow/Pillow)
 - requests
 
 ## Example


### PR DESCRIPTION
The changes proposed in #46 are not reflected in the README, which flummoxed me a little as the installation was failing with Pillow 5.3.0 installed - this PR updates the docs to reflect the changed requirement