### PR TITLE
Commented out line 118

### DIFF
--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -646,7 +646,7 @@ class HTMLTextParser(HTMLParser):
                 data = data.lstrip()
 
             data = data.replace("\n", " ").replace("\t", " ")
-            data = f"{data} " # FIXME: attaching a space in blind is wrong
+            data = f"{data}" # FIXME: attaching a space in blind is wrong - SPACE REMOVED
             data = self._remove_multi_spaces(data)
             if len(self.html_tags) and self.html_tags[-1] in (
                 HTML.Tag.UL,

--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -115,7 +115,7 @@ class HTML:
         Tag.DIV,
         Tag.P,
         Tag.PRE,
-        Tag.CODE,
+        #Tag.CODE,
         Tag.TABLE,
         Tag.TR,
     )


### PR DESCRIPTION
This ensures <code> </code> remains inline. However <pre><code> </code></pre> will still render as a separate block.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Adjusted the handling of <code> tags in the HTML parser to ensure inline rendering, while maintaining block rendering for <pre><code>.

- **Bug Fixes**:
    - Commented out Tag.CODE in the list of tags to ensure <code> remains inline while <pre><code> renders as a separate block.

<!-- Generated by sourcery-ai[bot]: end summary -->