### PR TITLE
add support for base64 embedded images

### DIFF
--- a/tkhtmlview/html_parser.py
+++ b/tkhtmlview/html_parser.py
@@ -11,6 +11,7 @@ from html.parser import HTMLParser
 from collections import OrderedDict
 import requests
 from io import BytesIO
+import base64
 
 
 # __________________________________________________________________________________________________
@@ -542,6 +543,24 @@ class HTMLTextParser(HTMLParser):
                         self.cached_images[attrs[HTML.Attrs.SRC]] = deepcopy(image)
                     except:
                         pass
+
+            if attrs[HTML.Attrs.SRC].startswith(("data:image/jpeg;base64,")):
+                try:
+                    image = Image.open(
+                        BytesIO(base64.b64decode(attrs[HTML.Attrs.SRC][23:].encode("utf-8")))
+                    )
+                    self.cached_images[attrs[HTML.Attrs.SRC]] = deepcopy(image)
+                except:
+                    pass
+
+            if attrs[HTML.Attrs.SRC].startswith(("data:image/png;base64,", "data:image/gif;base64,")):
+                try:
+                    image = Image.open(
+                        BytesIO(base64.b64decode(attrs[HTML.Attrs.SRC][22:].encode("utf-8")))
+                    )
+                    self.cached_images[attrs[HTML.Attrs.SRC]] = deepcopy(image)
+                except:
+                    pass
 
             if attrs[HTML.Attrs.SRC] in self.cached_images.keys():
                 image = deepcopy(self.cached_images[attrs[HTML.Attrs.SRC]])


### PR DESCRIPTION
The HTML <img> tag supports images embedded directly into src attribute using base64 encoding, see for example [this question on SO](https://stackoverflow.com/questions/8499633/how-to-display-base64-images-in-html). I've added that trivial functionality to the parser since I needed it in my own project using tkhtmlview.